### PR TITLE
feat: voteStatus를 이용하여 팀 목록을 정렬하는 기능 구현

### DIFF
--- a/src/main/java/ssafy/lambda/vote/controller/VoteController.java
+++ b/src/main/java/ssafy/lambda/vote/controller/VoteController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import ssafy.lambda.vote.dto.RequestVoteDto;
 import ssafy.lambda.vote.dto.ResponseProfileWithPercentDto;
+import ssafy.lambda.vote.dto.ResponseVoteStatusDto;
 import ssafy.lambda.vote.dto.ResponseVoteDto;
 import ssafy.lambda.vote.service.VoteService;
 
@@ -25,24 +26,27 @@ public class VoteController {
         @RequestParam Long memberId,
         @RequestParam Long teamId,
         @RequestBody RequestVoteDto requestVoteDto
-    ){
-        log.info("createVote - team {}, memberId {} : {}", teamId, memberId, requestVoteDto.toString());
+    ) {
+        log.info("createVote - team {}, memberId {} : {}", teamId, memberId,
+            requestVoteDto.toString());
         voteService.createVote(memberId, teamId, requestVoteDto);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok()
+                             .build();
     }
 
 
     @Operation(summary = "투표하기", description = "유저가 투표를 합니다")
     @PostMapping("/vote/{voteId}")
     public ResponseEntity createVote(
-            @PathVariable Long voteId,
-            @RequestParam Long memberId,
-            @RequestParam Long choosedMemberId,
-            @RequestParam Long teamId
-    ){
-        log.info("doVote - team {}, vote {} : {} -> {}", teamId, voteId, memberId, choosedMemberId );
+        @PathVariable Long voteId,
+        @RequestParam Long memberId,
+        @RequestParam Long choosedMemberId,
+        @RequestParam Long teamId
+    ) {
+        log.info("doVote - team {}, vote {} : {} -> {}", teamId, voteId, memberId, choosedMemberId);
         voteService.doVote(voteId, teamId, memberId, choosedMemberId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok()
+                             .build();
     }
 
     @Operation(summary = "한줄평 남기기", description = "유저가 투표한 유저에게 한줄평를 남깁니다")
@@ -51,10 +55,11 @@ public class VoteController {
         @PathVariable Long voteId,
         @RequestParam Long memberId,
         @RequestBody String review
-    ){
-        log.info("review - member {}, vote {}  : {}", memberId, voteId, review );
+    ) {
+        log.info("review - member {}, vote {}  : {}", memberId, voteId, review);
         voteService.review(memberId, voteId, review);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok()
+                             .build();
     }
 
 
@@ -62,10 +67,11 @@ public class VoteController {
     @GetMapping("/vote/{voteId}")
     public ResponseEntity<List<ResponseProfileWithPercentDto>> getVoteResult(
         @PathVariable Long voteId
-    ){
+    ) {
         log.info("voteResult - vote {} ");
         List<ResponseProfileWithPercentDto> voteResult = voteService.voteResult(voteId);
-        return ResponseEntity.ok().body(voteResult);
+        return ResponseEntity.ok()
+                             .body(voteResult);
     }
 
     @Operation(summary = "투표 리스트 가져오기", description = "유저가 선택한 그룹의 진행 중인 투표를 가져옵니다.")
@@ -78,7 +84,18 @@ public class VoteController {
         log.info("member {}, team {} -> ListCount : {}", memberId, teamId,
             responseVoteDtoList.size());
 
-        return ResponseEntity.ok().body(responseVoteDtoList);
+        return ResponseEntity.ok()
+                             .body(responseVoteDtoList);
     }
 
+    @GetMapping("/vote/sortList")
+    public ResponseEntity<ResponseVoteStatusDto> teamSortList(
+        @RequestParam Long memberId,
+        @RequestParam Long teamId
+    ) {
+        ResponseVoteStatusDto responseVoteStatusDto = voteService.sortByVoteStatus(null, null);
+
+        return ResponseEntity.ok()
+                             .body(responseVoteStatusDto);
+    }
 }

--- a/src/main/java/ssafy/lambda/vote/dto/ResponseVoteStatusDto.java
+++ b/src/main/java/ssafy/lambda/vote/dto/ResponseVoteStatusDto.java
@@ -1,0 +1,17 @@
+package ssafy.lambda.vote.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+
+/**
+ * 투표상태에 따라 2개의 리스트로 분리하여 반환
+ * inComplatedTeam
+ */
+@Data
+public class ResponseVoteStatusDto {
+
+    //TeamId를 반환하도록 <Long> 타입으로 설정
+    List<Long> completedTeams = new ArrayList<>();
+    List<Long> inCompletedTeams = new ArrayList<>();
+}

--- a/src/main/java/ssafy/lambda/vote/repository/VoteRepositoryCustom.java
+++ b/src/main/java/ssafy/lambda/vote/repository/VoteRepositoryCustom.java
@@ -4,7 +4,10 @@ import java.util.List;
 import ssafy.lambda.member.entity.Member;
 import ssafy.lambda.team.entity.Team;
 import ssafy.lambda.vote.dto.ResponseVoteDto;
+import ssafy.lambda.vote.entity.Vote;
 
 public interface VoteRepositoryCustom {
     List<ResponseVoteDto> findVoteByMemberAndTeam(Member member, Team team);
+
+    Vote findInCompleteVoteByMemberAndTeam(Member member, Team team);
 }

--- a/src/main/java/ssafy/lambda/vote/service/VoteService.java
+++ b/src/main/java/ssafy/lambda/vote/service/VoteService.java
@@ -1,10 +1,10 @@
 package ssafy.lambda.vote.service;
 
-import ssafy.lambda.vote.dto.RequestVoteDto;
-import ssafy.lambda.vote.dto.ResponseVoteDto;
-
 import java.util.List;
+import ssafy.lambda.vote.dto.RequestVoteDto;
 import ssafy.lambda.vote.dto.ResponseProfileWithPercentDto;
+import ssafy.lambda.vote.dto.ResponseVoteStatusDto;
+import ssafy.lambda.vote.dto.ResponseVoteDto;
 
 public interface VoteService {
     void createVote(Long memberId, Long teamId, RequestVoteDto requestVoteDto);
@@ -14,5 +14,8 @@ public interface VoteService {
     void review(Long memberId, Long voteId, String review);
 
     List<ResponseProfileWithPercentDto> voteResult(Long voteId);
+
     List<ResponseVoteDto> getUserVote(Long memberId, Long teamId);
+
+    ResponseVoteStatusDto sortByVoteStatus(Long memberId, List<Long> teamIds);
 }


### PR DESCRIPTION
## 📝작업 내용
Issue : #19 
- VoteRepository (멤버, 팀) -> 진행 중인, 아직 멤버가 투표하지 않은, 마감 기한이 가장 빠른 투표 1개 를 반환하는 쿼리 작성
- VoteService VoteRepository의 해당 메서드를 통해 Team을 정렬하는 서비스 구현
    - 정렬 우선 순위
    1.  멤버가 아직 투표하지 않은 투표가 해당 팀에 존재하는 경우 우선
    2. 아직 수행하지 않은 투표들이 남아있는 팀들 간 -> 마감 기한이 가장 빠른 투표 우선
- 이를 받아서 반환할 ResponseVoteStatusDto 개발 

## 💬리뷰 요구사항
1. 현재 쿼리는 멤버 1명이 속한 팀이 n명일 때 n번쿼리를 호출하는 로직으로 작성되었습니다.              
   이를 1번의 쿼리로 최적화 할 수 있는 아이디어가 있을까요??
2. (1)번이 만약 최선의 쿼리라면 Service에서의 정렬 로직을 조금 더 깔끔하게 다듬을 수 있을까요?
3. ResponseVoteStatusDto는 현재 Team의 id를 제네릭으로 가지고 있습니다.            
    반환하는 결과값에 대한 논의가 필요합니다.


## ✅제출 전 필수 확인 사항
- [x] 빌드가 되는 코드인가요?
- [x] 버그가 발생하지 않는지 충분히 테스트 해봤나요?
