### PR TITLE
Member DTO 수정 및 Member와 Team 기능 추가

### DIFF
--- a/src/main/java/ssafy/lambda/member/dto/RequestMemberDto.java
+++ b/src/main/java/ssafy/lambda/member/dto/RequestMemberDto.java
@@ -12,7 +12,6 @@ import ssafy.lambda.member.entity.SocialType;
 @Getter
 public class RequestMemberDto {
 
-    private Long memberId;
     private SocialType social;
     private String name;
     private Integer point;
@@ -21,7 +20,6 @@ public class RequestMemberDto {
 
     public Member toEntity() {
         return Member.builder()
-            .memberId(memberId)
             .social(social)
             .name(name)
             .point(point)

--- a/src/main/java/ssafy/lambda/member/dto/ResponseMemberDto.java
+++ b/src/main/java/ssafy/lambda/member/dto/ResponseMemberDto.java
@@ -11,12 +11,10 @@ public class ResponseMemberDto {
     private final Long memberId;
     private final String profileImgUrl;
     private final String email;
-    private final List<Membership> memberships;
 
     public ResponseMemberDto(Member member) {
         this.memberId = member.getMemberId();
         this.profileImgUrl = member.getProfileImgUrl();
         this.email = member.getEmail();
-        this.memberships = member.getMemberships();
     }
 }

--- a/src/main/java/ssafy/lambda/member/repository/MemberRepository.java
+++ b/src/main/java/ssafy/lambda/member/repository/MemberRepository.java
@@ -22,6 +22,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findAll();
 
 
-    @Query("SELECT member from Member member LEFT JOIN member.memberships membership LEFT JOIN membership.team team where team.id = :teamId")
+    @Query("SELECT m FROM Member m JOIN m.memberships WHERE memberships.team.id = :teamId")
     List<Member> findAllByTeamId(Long teamId);
 }

--- a/src/main/java/ssafy/lambda/member/repository/MemberRepository.java
+++ b/src/main/java/ssafy/lambda/member/repository/MemberRepository.java
@@ -4,8 +4,10 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import ssafy.lambda.member.entity.Member;
+import ssafy.lambda.membership.entity.Membership;
 
 
 @Repository
@@ -18,4 +20,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Override
     @EntityGraph(attributePaths = {"memberships"})
     List<Member> findAll();
+
+
+    @Query("SELECT member from Member member LEFT JOIN member.memberships membership LEFT JOIN membership.team team where team.id = :teamId")
+    List<Member> findAllByTeamId(Long teamId);
 }

--- a/src/main/java/ssafy/lambda/member/service/MemberService.java
+++ b/src/main/java/ssafy/lambda/member/service/MemberService.java
@@ -8,6 +8,11 @@ import ssafy.lambda.member.dto.RequestMemberDto;
 import ssafy.lambda.member.entity.Member;
 import ssafy.lambda.member.exception.MemberNotFoundException;
 import ssafy.lambda.member.repository.MemberRepository;
+import ssafy.lambda.membership.entity.Membership;
+import ssafy.lambda.membership.service.MembershipService;
+import ssafy.lambda.team.entity.Team;
+import ssafy.lambda.team.repository.TeamRepository;
+import ssafy.lambda.team.service.TeamService;
 
 @Service
 @RequiredArgsConstructor
@@ -46,5 +51,9 @@ public class MemberService {
     @Transactional
     public List<Member> findAllMember() {
         return memberRepository.findAll();
+    }
+
+    public List<Member> findAllMemberByTeamId(Long teamId) {
+        return memberRepository.findAllByTeamId(teamId);
     }
 }

--- a/src/main/java/ssafy/lambda/team/repository/TeamRepository.java
+++ b/src/main/java/ssafy/lambda/team/repository/TeamRepository.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import ssafy.lambda.member.entity.Member;
 import ssafy.lambda.team.entity.Team;
 
 @Repository
@@ -17,4 +19,7 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     @Override
     @EntityGraph(attributePaths = {"memberships"})
     List<Team> findAll();
+
+    @Query("SELECT team from Team team LEFT JOIN team.memberships membership LEFT JOIN membership.member member where member.id = :memberId")
+    List<Team> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/ssafy/lambda/team/repository/TeamRepository.java
+++ b/src/main/java/ssafy/lambda/team/repository/TeamRepository.java
@@ -20,6 +20,6 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     @EntityGraph(attributePaths = {"memberships"})
     List<Team> findAll();
 
-    @Query("SELECT team from Team team LEFT JOIN team.memberships membership LEFT JOIN membership.member member where member.id = :memberId")
+    @Query("SELECT t FROM Team t JOIN t.memberships WHERE memberships.member.id = :memberId")
     List<Team> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/ssafy/lambda/team/service/TeamService.java
+++ b/src/main/java/ssafy/lambda/team/service/TeamService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import ssafy.lambda.member.entity.Member;
 import ssafy.lambda.team.dto.RequestTeamDto;
 import ssafy.lambda.team.entity.Team;
 import ssafy.lambda.team.repository.TeamRepository;
@@ -45,4 +46,7 @@ public class TeamService {
         return teamRepository.findAll();
     }
 
+    public List<Team> findAllTeamByMemberId(Long memberId) {
+        return teamRepository.findAllByMemberId(memberId);
+    }
 }


### PR DESCRIPTION
## 📝작업 내용
Issue: #37 
- RequestMemberDto에서 memberId 삭제
- ResponseMemberDto에서 List<Membership> 삭제
- Member Service에 teamId 기준으로 List<Member> 반환하는 기능 추가
- Team Service에 memberId 기준으로 List<Team> 반환하는 기능 추가


## 💬리뷰 요구사항
- 현재 Membership에서 teamId/memberId를 기준으로 List<Membership>을 반환해주고 있는 부분을 Team과 Member에서 List<Member/Team>으로 반환하는 기능으로 바꾸어 순환참조도 피하고 보내는 쿼리 횟수 줄일려고 하는데 의견을 공유해주세요!
- 추가된 기능은 현재 join을 2번 사용하고 있는데 더 좋은 구현이 있다면 알려주세요!
- 현재는 fetch join을 사용하지 않고 있는데 필요하다면 알려주세요!


## ✅제출 전 필수 확인 사항
- [x] 빌드가 되는 코드인가요?
- [x] 버그가 발생하지 않는지 충분히 테스트 해봤나요?
