### PR TITLE
DataResponse 생성, Swagger custom annotation 생성

### DIFF
--- a/src/main/java/ssafy/lambda/global/annotation/ApiErrorResponse.java
+++ b/src/main/java/ssafy/lambda/global/annotation/ApiErrorResponse.java
@@ -1,0 +1,20 @@
+package ssafy.lambda.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import ssafy.lambda.global.response.ApiError;
+
+/**
+ * Controller 에 붙여서 사용하는 API 에서 생길수 있는 에러들을 쉽게 정의할 수 있는 커스텀 어노테이션 입니다.
+ *
+ * @ApiErrorResponse([]) => 배열 안에 ApiErrorResponse Enum 을 넣으면 작동합니다.
+ */
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorResponse {
+
+    ApiError[] value();
+}

--- a/src/main/java/ssafy/lambda/global/annotation/ApiErrorResponse.java
+++ b/src/main/java/ssafy/lambda/global/annotation/ApiErrorResponse.java
@@ -9,7 +9,7 @@ import ssafy.lambda.global.response.ApiError;
 /**
  * Controller 에 붙여서 사용하는 API 에서 생길수 있는 에러들을 쉽게 정의할 수 있는 커스텀 어노테이션 입니다.
  *
- * @ApiErrorResponse([]) => 배열 안에 ApiErrorResponse Enum 을 넣으면 작동합니다.
+ * @ApiErrorResponse({)) => 배열 안에 ApiErrorResponse Enum 을 넣으면 작동합니다.
  */
 
 @Target(ElementType.METHOD)

--- a/src/main/java/ssafy/lambda/global/config/SwaggerConfig.java
+++ b/src/main/java/ssafy/lambda/global/config/SwaggerConfig.java
@@ -1,0 +1,77 @@
+package ssafy.lambda.global.config;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+import ssafy.lambda.global.annotation.ApiErrorResponse;
+import ssafy.lambda.global.response.ApiError;
+import ssafy.lambda.global.response.dto.Response;
+
+/**
+ * Swagger 설정 Configuration 입니다. 커스텀 어노테이션을 사용하기 위해 사용하였습니다.
+ */
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            // 커스텀한 어노테이션을 가져온다.
+            ApiErrorResponse apiErrorResponse = handlerMethod.getMethodAnnotation(
+                ApiErrorResponse.class);
+            if (apiErrorResponse != null) {
+                // 어노테이션에 넣은 Enum 배열을 인자로 넘겨준다.
+                generateResponse(operation, apiErrorResponse.value());
+            }
+            return operation;
+        };
+    }
+
+    private void generateResponse(Operation operation,
+        ApiError[] apiError) {
+        ApiResponses apiResponses = operation.getResponses();
+        Map<Integer, List<ApiError>> responseInfoMap = new HashMap<>();
+        // HttpStatus 를 key 로 가지는 map 을 만든다.
+        for (ApiError responseInfo : apiError) {
+            responseInfoMap.putIfAbsent(responseInfo.getStatus()
+                                                    .value(), new ArrayList<>());
+            responseInfoMap.get(responseInfo.getStatus()
+                                            .value())
+                           .add(responseInfo);
+        }
+        // 각 Enum 별로 Example 을 정의한다.
+        responseInfoMap.forEach((key, infoList) -> {
+            Content content = new Content();
+            MediaType mediaType = new MediaType();
+            ApiResponse apiResponse = new ApiResponse();
+            infoList.forEach(info -> {
+                Example example = new Example();
+                example.setSummary(info.getName());
+                example.setDescription(info.getDescription());
+                example.setValue(new Response(info.getStatus(), info.getMessage()));
+                System.out.println(info.getName());
+                mediaType.addExamples(String.valueOf(info.getName()), example);
+            });
+            content.addMediaType("application/json", mediaType);
+            apiResponse.setContent(content);
+            apiResponses.addApiResponse(String.valueOf(key), apiResponse);
+        });
+
+
+    }
+
+}

--- a/src/main/java/ssafy/lambda/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ssafy/lambda/global/exception/GlobalExceptionHandler.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import ssafy.lambda.global.response.Response;
+import ssafy.lambda.global.response.dto.Response;
 import ssafy.lambda.invitation.exception.DuplicatedInvitationException;
 import ssafy.lambda.invitation.exception.InvalidInvitationException;
 import ssafy.lambda.invitation.exception.InvitationNotFoundException;

--- a/src/main/java/ssafy/lambda/global/response/ApiError.java
+++ b/src/main/java/ssafy/lambda/global/response/ApiError.java
@@ -1,0 +1,27 @@
+package ssafy.lambda.global.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * API 에서 발생할 수 있는 오류를 정의해놓는 Enum Class 입니다. Enum 이름(HttpStatus, 오류 이름, 오류 메세지 예시, 오류에 대한 설명) 으로
+ * 생성하면 됩니다.
+ */
+
+@Getter
+@RequiredArgsConstructor
+public enum ApiError {
+    ExampleCreated(HttpStatus.NOT_IMPLEMENTED, "예제 오류", "예제를 찾지 못했어요", "예제 설명"),
+    MemberNotFound(HttpStatus.NOT_FOUND, "멤버 찾기 오류", "멤버 를 찾지 못했습니다. Id -> {memberId}",
+        "멤버를 찾지 못했을때 생기는 오류입니다. id 로 멤버를 검색했지만 찾지 못했을 경우 발생합니다."),
+    TeamNotFound(HttpStatus.NOT_FOUND, "팀 찾기 오륲", "팀을 찾지 못했습니다. name -> {teamName}",
+        "팀을 찾지 못했습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String name;
+    private final String message;
+    private final String description;
+
+}

--- a/src/main/java/ssafy/lambda/global/response/Response.java
+++ b/src/main/java/ssafy/lambda/global/response/Response.java
@@ -1,29 +1,24 @@
 package ssafy.lambda.global.response;
 
 
-import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-
 @Getter
-@Setter
-@ToString
-@Builder
 public class Response {
 
-    private HttpStatus status;
-    private String message;
+    private final HttpStatus status;
+    private final String message;
 
-    public static ResponseEntity<Response> res(HttpStatus status, String message) {
+    public Response(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public static ResponseEntity res(HttpStatus status, String message) {
         return ResponseEntity
             .status(status)
-            .body(Response.builder()
-                .message(message)
-                .status(status)
-                .build());
+            .body(new Response(status, message));
     }
 }

--- a/src/main/java/ssafy/lambda/global/response/ResponseData.java
+++ b/src/main/java/ssafy/lambda/global/response/ResponseData.java
@@ -1,0 +1,24 @@
+package ssafy.lambda.global.response;
+
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+public class ResponseData<T> extends Response {
+
+    private final T data;
+
+    public ResponseData(HttpStatus status, String message, T data) {
+        super(status, message);
+        this.data = data;
+    }
+
+    public static <T> ResponseEntity res(HttpStatus status, String message,
+        T data) {
+        return ResponseEntity
+            .status(status)
+            .body(new ResponseData<>(status, message, data));
+    }
+}

--- a/src/main/java/ssafy/lambda/global/response/dto/Response.java
+++ b/src/main/java/ssafy/lambda/global/response/dto/Response.java
@@ -1,4 +1,4 @@
-package ssafy.lambda.global.response;
+package ssafy.lambda.global.response.dto;
 
 
 import lombok.Getter;

--- a/src/main/java/ssafy/lambda/global/response/dto/ResponseData.java
+++ b/src/main/java/ssafy/lambda/global/response/dto/ResponseData.java
@@ -1,4 +1,4 @@
-package ssafy.lambda.global.response;
+package ssafy.lambda.global.response.dto;
 
 
 import lombok.Getter;

--- a/src/main/java/ssafy/lambda/invitation/controller/InvitationController.java
+++ b/src/main/java/ssafy/lambda/invitation/controller/InvitationController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import ssafy.lambda.global.response.Response;
+import ssafy.lambda.global.response.dto.Response;
 import ssafy.lambda.invitation.dto.RequestAcceptInvitationDto;
 import ssafy.lambda.invitation.dto.RequestCreateInvitationDto;
 import ssafy.lambda.invitation.dto.ResponseInvitationDto;

--- a/src/main/java/ssafy/lambda/member/controller/MemberController.java
+++ b/src/main/java/ssafy/lambda/member/controller/MemberController.java
@@ -13,6 +13,10 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import ssafy.lambda.global.annotation.ApiErrorResponse;
+import ssafy.lambda.global.response.ApiError;
+import ssafy.lambda.global.response.dto.Response;
+import ssafy.lambda.global.response.dto.ResponseData;
 import ssafy.lambda.member.dto.RequestMemberDto;
 import ssafy.lambda.member.dto.ResponseMemberDto;
 import ssafy.lambda.member.entity.Member;
@@ -25,53 +29,48 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @Operation(summary = "유저 목록 조회", description = "유저 목록을 조회합니다")
+    @Operation(summary = "멤버 목록 조회", description = "멤버 목록을 조회합니다")
     @GetMapping
     public ResponseEntity<List<ResponseMemberDto>> getMembers() {
         List<ResponseMemberDto> members = memberService.findAllMember()
-            .stream()
-            .map(ResponseMemberDto::new)
-            .toList();
-
-        return ResponseEntity.status(HttpStatus.OK)
-            .body(members);
+                                                       .stream()
+                                                       .map(ResponseMemberDto::new)
+                                                       .toList();
+        return ResponseData.res(HttpStatus.CREATED, "멤버 리스트 반환", members);
     }
 
-    @Operation(summary = "유저 조회", description = "유저 정보를 조회합니다")
+    @Operation(summary = "멤버 조회", description = "멤버 정보를 조회합니다")
+    @ApiErrorResponse({ApiError.MemberNotFound})
     @GetMapping("{id}")
     public ResponseEntity<ResponseMemberDto> getMember(@PathVariable("id") Long id) {
         Member member = memberService.findMemberById(id);
-
-        return ResponseEntity.status(HttpStatus.OK)
-            .body(new ResponseMemberDto(member));
+        return ResponseData.res(HttpStatus.OK, "멤버 정보 조회", new ResponseMemberDto(member));
     }
 
-    @Operation(summary = "유저 생성", description = "새로운 유저를 생성합니다")
+    @Operation(summary = "멤버 등록", description = "새로운 멤버를 등록합니다")
+    @ApiErrorResponse({ApiError.MemberNotFound,
+        ApiError.ExampleCreated})
     @PostMapping
     public ResponseEntity<ResponseMemberDto> register(
         @RequestBody RequestMemberDto requestMemberDto) {
         Member savedMember = memberService.createMember(requestMemberDto);
-
-        return ResponseEntity.status(HttpStatus.CREATED)
-            .body(new ResponseMemberDto(savedMember));
+        return Response.res(HttpStatus.CREATED, "멤버 등록 성공");
     }
 
-    @Operation(summary = "유저 갱신", description = "유저 정보를 갱신합니다")
+    @Operation(summary = "멤버 갱신", description = "멤버 정보를 갱신합니다")
+    @ApiErrorResponse({ApiError.MemberNotFound})
     @PutMapping("{id}")
     public ResponseEntity<ResponseMemberDto> update(@PathVariable("id") Long id,
         @RequestBody RequestMemberDto requestMemberDto) {
         Member updatedMember = memberService.updateMember(id, requestMemberDto);
-
-        return ResponseEntity.status(HttpStatus.OK)
-            .body(new ResponseMemberDto(updatedMember));
+        return Response.res(HttpStatus.OK, "멤버 정보 갱신 성공");
     }
 
-    @Operation(summary = "유저 삭제", description = "유저를 삭제합니다")
+    @Operation(summary = "멤버 삭제", description = "멤버를 삭제합니다")
+    @ApiErrorResponse({ApiError.MemberNotFound})
     @DeleteMapping("{id}")
     public ResponseEntity<ResponseMemberDto> delete(@PathVariable("id") Long id) {
         memberService.deleteMemberById(id);
-
-        return ResponseEntity.status(HttpStatus.OK)
-            .build();
+        return Response.res(HttpStatus.OK, "멤버 삭제 성공");
     }
 }

--- a/src/main/java/ssafy/lambda/team/controller/TeamController.java
+++ b/src/main/java/ssafy/lambda/team/controller/TeamController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import ssafy.lambda.global.response.Response;
+import ssafy.lambda.global.response.dto.Response;
 import ssafy.lambda.member.entity.Member;
 import ssafy.lambda.member.service.MemberService;
 import ssafy.lambda.team.dto.RequestTeamCreateDto;


### PR DESCRIPTION
## 📝작업 내용
issue : #47 

- response 에 data 가 있을때 사용하는 ResponseData 클래스를 생성하였습니다.
- API 에서 발생하는 에러를 Swagger 에 쉽게 등록할 수 있는 custom annotation 을 생성하였습니다.
- API 에서 발생하는 에러를 ApiError Enum 에 미리 등록한 후 @ApiErrorResponse({)) 배열 안에 넣어주면 됩니다.
- MemberController 에 예시로 적용해 놓았으니 보고 참고하시면 됩니다. 
<img width="765" alt="스크린샷 2024-05-10 오후 12 26 56" src="https://github.com/SSA-FY/backend/assets/76129597/8a85932a-eeff-4e5a-b427-50e4d33df17e">

사진과 같이 HttpStatus code 에 따라 example 들이 생기고 예시 에러 메세지를 볼 수 있습니다. 


## 💬리뷰 요구사항

<img width="255" alt="스크린샷 2024-05-10 오후 12 13 36" src="https://github.com/SSA-FY/backend/assets/76129597/c976b114-9677-4c15-bbc8-c504fbfc766d">

- 적용시 이와 같이 데이터만을 반환하는 API 에도 status 와 message 가 들어가는데 이게 맞는 설계인지 잘 모르겠습니다. (created 는 예시인데 잘못들어가서 수정하겠습니다. ) 
- 에러 메세지 예시에 추가로 들어갔으면 좋을 정보가 있으면 말씀해주세요 



## ✅제출 전 필수 확인 사항
- [x] 빌드가 되는 코드인가요?
- [x] 버그가 발생하지 않는지 충분히 테스트 해봤나요?
