### PR TITLE
fix: 그룹 생성시 imgUrl 에러

### DIFF
--- a/src/main/java/ssafy/lambda/team/service/TeamServiceImpl.java
+++ b/src/main/java/ssafy/lambda/team/service/TeamServiceImpl.java
@@ -43,10 +43,12 @@ public class TeamServiceImpl implements TeamService {
 
         Team team = teamCreateDto.toEntity();
         team.setManager(manager);
+        teamRepository.save(team);
+
         team.setImgUrl(uploadImg(team.getTeamId(), img));
         teamRepository.save(team);
         membershipService.createMembership(manager, team, teamCreateDto.getManagerName());
-        
+
     }
 
     public Team findTeamById(Long teamId) {


### PR DESCRIPTION
## 📝작업 내용
그룹 생성 시, 최초의 teamId가 없어서 imgUrl이 잘못 들어가는 에러


## 💬리뷰 요구사항



## ✅제출 전 필수 확인 사항
- [ ] 빌드가 되는 코드인가요?
- [ ] 버그가 발생하지 않는지 충분히 테스트 해봤나요?
